### PR TITLE
修复 list ($key, $value) = explode(':', $line); explode分割字符导致的问题，有些head…

### DIFF
--- a/Curl.php
+++ b/Curl.php
@@ -472,8 +472,8 @@ class Curl
             if ($i === 0) {
                 $headers['http_code'] = $line;
             } else {
-                list ($key, $value) = explode(': ', $line);
-                $headers[$key] = $value;
+                list ($key, $value) = explode(':', $line);
+                $headers[$key] = ltrim($value);
             }
         }
 


### PR DESCRIPTION
修复 list ($key, $value) = explode(':', $line); explode分割字符导致的问题，有些head…