### PR TITLE
(Get Request) Fix issue with _httpRequest parameters

### DIFF
--- a/Curl.php
+++ b/Curl.php
@@ -8,7 +8,7 @@
  * @author    Nils Gajsek <info@linslin.org>
  * @copyright 2013-2017 Nils Gajsek <info@linslin.org>
  * @license   http://opensource.org/licenses/MIT MIT Public
- * @version   1.1.0
+ * @version   1.1.1
  * @link      http://www.linslin.org
  *
  */
@@ -130,7 +130,7 @@ class Curl
     public function get($url, $raw = true)
     {
         $this->_baseUrl = $url;
-        return $this->_httpRequest('GET', $url, $raw);
+        return $this->_httpRequest('GET', $raw);
     }
 
 

--- a/codeception.yml
+++ b/codeception.yml
@@ -16,8 +16,7 @@ extensions:
     config:
         Codeception\Extension\Phiremock:
             listen: 127.0.0.1:18080 # defaults to 0.0.0.0:8086
-            bin_path: ..\vendor\bin # defaults to codeception_dir/../vendor/bin
-            logs_path: /var/log/my_app/tests/logs # defaults to codeception's tests output dir
+            bin_path: vendor/bin # defaults to codeception_dir/../vendor/bin
             debug: true # defaults to false
             startDelay: 1 # default to 0
 modules:

--- a/tests/acceptance/httpMockCest.php
+++ b/tests/acceptance/httpMockCest.php
@@ -214,4 +214,53 @@ class httpMockCest
             ->post($this->_endPoint.'/test/params/post');
         $I->assertEquals($this->_curl->responseCode, 200);
     }
+
+    /**
+     * Get JSON response test
+     * @param \AcceptanceTester $I
+     */
+    public function getWithDecodedJsonResponseTest(\AcceptanceTester $I)
+    {
+        //Init
+        $this->_curl->reset();
+
+        $I->expectARequestToRemoteServiceWithAResponse(
+            $expectation = Phiremock::on(
+                A::getRequest()->andUrl(Is::equalTo('/test/params/get/json'))
+            )->then(
+                Respond::withStatusCode(200)
+                    ->andBody('{"id": 1, "description": "I am a resource"}')
+            )
+        );
+
+        $jsonResponse = $this->_curl->get($this->_endPoint . '/test/params/get/json', false);
+        $I->assertEquals($this->_curl->responseCode, 200);
+        $I->assertArrayHasKey('id', $jsonResponse);
+        $I->assertArrayHasKey('description', $jsonResponse);
+        $I->assertEquals($jsonResponse['id'], 1);
+        $I->assertEquals($jsonResponse['description'], 'I am a resource');
+    }
+
+    /**
+     * Get JSON response test
+     * @param \AcceptanceTester $I
+     */
+    public function getWithRawJsonResponseTest(\AcceptanceTester $I)
+    {
+        //Init
+        $this->_curl->reset();
+
+        $I->expectARequestToRemoteServiceWithAResponse(
+            $expectation = Phiremock::on(
+                A::getRequest()->andUrl(Is::equalTo('/test/params/get/json'))
+            )->then(
+                Respond::withStatusCode(200)
+                    ->andBody('{"id": 1, "description": "I am a resource"}')
+            )
+        );
+
+        $rawResponse = $this->_curl->get($this->_endPoint . '/test/params/get/json', true);
+        $I->assertEquals($this->_curl->responseCode, 200);
+        $I->assertEquals($rawResponse, '{"id": 1, "description": "I am a resource"}');
+    }
 }


### PR DESCRIPTION
Remove `url` parameter used in _httpRequest call and update tests.
Update Codeception bin path and remove `logs_path` so default is used