### PR TITLE
Fix undefined constant YII_DEBUG

### DIFF
--- a/Curl.php
+++ b/Curl.php
@@ -616,7 +616,7 @@ class Curl
         }
 
         //setup error reporting and profiling
-        if (YII_DEBUG) {
+        if (defined('YII_DEBUG') && YII_DEBUG) {
             Yii::trace('Start sending cURL-Request: '.$this->getUrl().'\n', __METHOD__);
             Yii::beginProfile($method.' '.$this->_baseUrl.'#'.md5(serialize($this->getOption(CURLOPT_POSTFIELDS))), __METHOD__);
         }
@@ -662,7 +662,7 @@ class Curl
         $this->_extractAdditionalCurlParameter();
 
         //end yii debug profile
-        if (YII_DEBUG) {
+        if (defined('YII_DEBUG') && YII_DEBUG) {
             Yii::endProfile($method.' '.$this->getUrl().'#'.md5(serialize($this->getOption(CURLOPT_POSTFIELDS))), __METHOD__);
         }
 


### PR DESCRIPTION
[PHPUnit\Framework\Exception] Use of undefined constant YII_DEBUG - assumed 'YII_DEBUG' (this will throw an Error in a future version of PHP)